### PR TITLE
Add metacom

### DIFF
--- a/application/api/example/data.js
+++ b/application/api/example/data.js
@@ -1,0 +1,9 @@
+({
+  access: 'public',
+
+  method: async () => {
+    return 'Hello world';
+  },
+
+  returns: 'string',
+});

--- a/application/api/system/introspect.js
+++ b/application/api/system/introspect.js
@@ -1,0 +1,4 @@
+({
+  access: 'public',
+  method: application.introspect,
+});

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "1.0.0",
       "license": "MIT",
       "dependencies": {
-        "impress": "^3.0.11"
+        "impress": "^3.0.13"
       },
       "devDependencies": {
         "@flydotio/dockerfile": "^0.4.10",
@@ -25,6 +25,9 @@
         "lint-staged": "^14.0.1",
         "prettier": "3.0.3",
         "typescript": "^5.2.2"
+      },
+      "engines": {
+        "node": "18 || 20"
       }
     },
     "node_modules/@aashutoshrathi/word-wrap": {

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
     "node": "18 || 20"
   },
   "scripts": {
+    "dev": "node server.js",
     "start": "node server.js",
     "test": "MODE=test node server.js",
     "eslint:check": "eslint .",

--- a/package.json
+++ b/package.json
@@ -8,7 +8,6 @@
     "node": "18 || 20"
   },
   "scripts": {
-    "dev": "node server.js",
     "start": "node server.js",
     "test": "MODE=test node server.js",
     "eslint:check": "eslint .",

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
   },
   "license": "MIT",
   "dependencies": {
-    "impress": "^3.0.11"
+    "impress": "^3.0.13"
   },
   "devDependencies": {
     "@flydotio/dockerfile": "^0.4.10",


### PR DESCRIPTION
There are examples of endpoints which are used in https://github.com/dev-KPI/messenger-frontend/pull/45. I think we can merge them to test how it works and deploys. 